### PR TITLE
Replace qiskit simulation with random generator

### DIFF
--- a/quantum_sim.py
+++ b/quantum_sim.py
@@ -1,17 +1,38 @@
-from qiskit import QuantumCircuit, Aer, execute
+import numpy as np
 
-def run_quantum_experiment(b_measurement_basis):
-    qc = QuantumCircuit(2, 2)
-    qc.h(0)
-    qc.cx(0, 1)
-    qc.measure(0, 0)
-    if b_measurement_basis == 'Z':
-        qc.measure(1, 1)
-    elif b_measurement_basis == 'X':
-        qc.h(1)
-        qc.measure(1, 1)
-    backend = Aer.get_backend('qasm_simulator')
-    job = execute(qc, backend, shots=1)
-    result = job.result().get_counts()
-    key = list(result.keys())[0]
-    return int(key[1]), int(key[0])  # (A, B)
+"""Simple random-based quantum experiment simulation.
+
+This module provides a lightweight replacement for the previous Qiskit-based
+implementation. The function `run_quantum_experiment` generates synthetic data
+without requiring any external quantum computing libraries.
+"""
+
+
+def run_quantum_experiment(b_measurement_basis: str):
+    """Simulate a single trial of a two-qubit experiment.
+
+    Parameters
+    ----------
+    b_measurement_basis : str
+        Measurement basis for qubit B. Supported values are ``"Z"`` and ``"X"``.
+
+    Returns
+    -------
+    tuple[int, int]
+        A tuple ``(a, b)`` representing the measurement outcomes for qubits
+        A and B respectively.
+    """
+    # Randomly choose a result for qubit A
+    a = np.random.randint(2)
+
+    if b_measurement_basis == "Z":
+        # Correlated with A in Z basis
+        b = a
+    elif b_measurement_basis == "X":
+        # Anti-correlated with A in X basis
+        b = 1 - a
+    else:
+        # Fallback to independent random result
+        b = np.random.randint(2)
+
+    return a, b

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-qiskit
 numpy
 matplotlib
 scikit-learn


### PR DESCRIPTION
## Summary
- implement a lightweight random simulation in `quantum_sim.py`
- drop qiskit from `requirements.txt`

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*